### PR TITLE
meson: install headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,9 @@ libelf = static_library(
   install : true,
 )
 
+install_headers('contrib/elftoolchain/libelf/libelf.h', 'contrib/elftoolchain/libelf/gelf.h')
+install_headers('sys/sys/elf32.h', 'sys/sys/elf64.h', 'sys/sys/elf_common.h', subdir : 'sys')
+
 libelf_dep = declare_dependency(
   link_with : libelf,
   include_directories : include_directories('contrib/elftoolchain/common', 'contrib/elftoolchain/libelf', 'sys'),


### PR DESCRIPTION
This installs the headers in the prefix anlong with the library.
This allows packaging libelf for mingw.
I tested everything is installed neatly:
```
`-- mingw-w64-libelf-lfg-win32-git
    `-- usr
        |-- i686-w64-mingw32
        |   |-- include
        |   |   |-- gelf.h
        |   |   |-- libelf.h
        |   |   `-- sys
        |   |       |-- elf32.h
        |   |       |-- elf64.h
        |   |       `-- elf_common.h
        |   `-- lib
        |       |-- libelf.a
        |       `-- pkgconfig
        |           `-- libelf.pc
```
This should not break the msvc build, it just allows to do "meson install".