### PR TITLE
Fix meson.build to install headers and use right pkgconfig include paths

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,10 @@ libelf_dep = declare_dependency(
 pkg.generate(
   libelf,
   name : 'libelf',
-  subdirs : ['libelf'],
+  subdirs : ['common', 'libelf', 'sys'],
   version : meson.project_version(),
   description : 'libelf description',
 )
+install_subdir('contrib/elftoolchain/common', install_dir: 'include')
+install_subdir('contrib/elftoolchain/libelf', install_dir: 'include')
+install_subdir('sys', install_dir: 'include')


### PR DESCRIPTION
As-is, this module only works as a submodule/wrap, but can't be built and installed ahead of time. I'd like to fix Mesa's CI to have dependencies pre-installed and only rebuild Mesa itself, but this dependency is broken.